### PR TITLE
インスタンスのreset, start時はworldをCloud Storageから取得しないようにした

### DIFF
--- a/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
+++ b/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
@@ -448,6 +448,10 @@ func createInstance(ctx context.Context, is *compute.InstancesService, minecraft
 					Key:   "world",
 					Value: &minecraft.World,
 				},
+				&compute.MetadataItems{
+					Key:   "state",
+					Value: "new",
+				},
 			},
 		},
 		ServiceAccounts: []*compute.ServiceAccount{

--- a/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
+++ b/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
@@ -399,6 +399,7 @@ func createInstance(ctx context.Context, is *compute.InstancesService, minecraft
 
 	startupScriptURL := "gs://sinmetalcraft-minecraft-shell/minecraftserver-startup-script.sh"
 	shutdownScriptURL := "gs://sinmetalcraft-minecraft-shell/minecraftserver-shutdown-script.sh"
+	stateValue := "new"
 	newIns := &compute.Instance{
 		Name:        name,
 		Zone:        "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/zones/" + minecraft.Zone,
@@ -450,7 +451,7 @@ func createInstance(ctx context.Context, is *compute.InstancesService, minecraft
 				},
 				&compute.MetadataItems{
 					Key:   "state",
-					Value: "new",
+					Value: &stateValue,
 				},
 			},
 		},

--- a/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
+++ b/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
@@ -411,7 +411,7 @@ func createInstance(ctx context.Context, is *compute.InstancesService, minecraft
 				DeviceName: name,
 				Mode:       "READ_WRITE",
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/global/images/minecraft-image-v20151113a",
+					SourceImage: "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/global/images/minecraft-image-v20151114a",
 					DiskType:    "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/zones/" + minecraft.Zone + "/diskTypes/pd-ssd",
 					DiskSizeGb:  100,
 				},

--- a/minecraftserver-backup.sh
+++ b/minecraftserver-backup.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
-screen -r mcs -X stuff '/save-all\n/save-off\n'
-sudo tar cvf world.tar world
-WORLD=$(curl http://metadata/computeMetadata/v1/instance/attributes/world -H "Metadata-Flavor: Google")
-GCSPATH="gs://sinmetalcraft-minecraft-world-dra/"
-TAR=".tar"
-WORLD_PATH=$GCSPATH$WORLD$TAR
-/usr/local/bin/gsutil cp world.tar $WORLD_PATH
-sudo rm world.tar
+# screen -r mcs -X stuff '/save-all\n/save-off\n'
+# sudo tar cvf world.tar world
+# WORLD=$(curl http://metadata/computeMetadata/v1/instance/attributes/world -H "Metadata-Flavor: Google")
+# GCSPATH="gs://sinmetalcraft-minecraft-world-dra/"
+# TAR=".tar"
+# WORLD_PATH=$GCSPATH$WORLD$TAR
+# /usr/local/bin/gsutil cp world.tar $WORLD_PATH
+# sudo rm world.tar

--- a/minecraftserver-backup.sh
+++ b/minecraftserver-backup.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+screen -r mcs -X stuff '/save-all\n/save-off\n'
+sudo tar cvf world.tar world
+WORLD=$(curl http://metadata/computeMetadata/v1/instance/attributes/world -H "Metadata-Flavor: Google")
+GCSPATH="gs://sinmetalcraft-minecraft-world-dra/"
+TAR=".tar"
+WORLD_PATH=$GCSPATH$WORLD$TAR
+/usr/local/bin/gsutil cp world.tar $WORLD_PATH
+sudo rm world.tar

--- a/minecraftserver-startup-script.sh
+++ b/minecraftserver-startup-script.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+STATE=$(curl http://metadata/computeMetadata/v1/instance/attributes/state -H "Metadata-Flavor: Google")
+echo $STATE
+if [ ${STATE} = "exists" ]; then
+  echo "EXISTS INSTNCE"
+  screen -d -m -S mcs java -Xms1G -Xmx7G -d64 -jar minecraft_server.1.8.jar nogui
+  exit 0
+fi
+echo "NEW INSTNCE"
 WORLD=$(curl http://metadata/computeMetadata/v1/instance/attributes/world -H "Metadata-Flavor: Google")
 GCSPATH="gs://sinmetalcraft-minecraft-world-dra/"
 TAR=".tar"
@@ -8,3 +16,6 @@ sudo gsutil cp $WORLD_PATH world.tar
 sudo tar xvf world.tar
 sudo rm world.tar
 screen -d -m -S mcs java -Xms1G -Xmx7G -d64 -jar minecraft_server.1.8.jar nogui
+gcloud compute instances add-metadata $HOSTNAME --zone=asia-east1-b --metadata state=exists
+gsutil cp gs://sinmetalcraft-minecraft-shell/minecraftserver-backup.sh backup.sh
+sudo chmod 755 backup.sh

--- a/minecraftserver-startup-script.sh
+++ b/minecraftserver-startup-script.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
+cd /home/minecraft
 STATE=$(curl http://metadata/computeMetadata/v1/instance/attributes/state -H "Metadata-Flavor: Google")
 echo $STATE
 if [ ${STATE} = "exists" ]; then
   echo "EXISTS INSTNCE"
+  sudo rm world/session.lock
   screen -d -m -S mcs java -Xms1G -Xmx7G -d64 -jar minecraft_server.1.8.jar nogui
   exit 0
 fi
@@ -10,11 +12,11 @@ echo "NEW INSTNCE"
 WORLD=$(curl http://metadata/computeMetadata/v1/instance/attributes/world -H "Metadata-Flavor: Google")
 GCSPATH="gs://sinmetalcraft-minecraft-world-dra/"
 TAR=".tar"
-cd /home/minecraft
 WORLD_PATH=$GCSPATH$WORLD$TAR
 sudo gsutil cp $WORLD_PATH world.tar
 sudo tar xvf world.tar
 sudo rm world.tar
+sudo rm world/session.lock
 screen -d -m -S mcs java -Xms1G -Xmx7G -d64 -jar minecraft_server.1.8.jar nogui
 gcloud compute instances add-metadata $HOSTNAME --zone=asia-east1-b --metadata state=exists
 gsutil cp gs://sinmetalcraft-minecraft-shell/minecraftserver-backup.sh backup.sh


### PR DESCRIPTION
shutdown scriptがうまく動いていない場合は、diskのデータを上書きして、巻き戻ってしまうため。 #16
