### PR TITLE
feat(gce): image-family 対応 refs #29

### DIFF
--- a/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
+++ b/appengine/sinmetalcraft/src/sinmetalcraft/sinmetalcraft.go
@@ -446,7 +446,7 @@ func createInstance(ctx context.Context, is *compute.InstancesService, minecraft
 				DeviceName: name,
 				Mode:       "READ_WRITE",
 				InitializeParams: &compute.AttachedDiskInitializeParams{
-					SourceImage: "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/global/images/minecraft-image-v20160426a",
+					SourceImage: "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/global/images/family/minecraft",
 					DiskType:    "https://www.googleapis.com/compute/v1/projects/" + PROJECT_NAME + "/zones/" + minecraft.Zone + "/diskTypes/pd-ssd",
 					DiskSizeGb:  100,
 				},


### PR DESCRIPTION
minecraft image-familyを参照するようにした。
これでminecraft versionを追従する時にいちいちGAE側を修正しなくてよくなるぞ！
